### PR TITLE
[DNS] Add the dev.getjjobs.nz cname to vercel

### DIFF
--- a/DNS/add-dev-cname.py
+++ b/DNS/add-dev-cname.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""
+Create a CNAME record for dev subdomain using Metaname's create_dns_record method.
+Supports both test and production environments.
+"""
+
+import requests
+import subprocess
+import json
+
+# --- Toggle for test or production ---
+use_test_api = False  # Set to False to use the production API
+
+API_ENDPOINT = (
+    "https://test.metaname.net/api/1.1"
+    if use_test_api else
+    "https://metaname.net/api/1.1"
+)
+vault_name = "JJobs"
+item_name = "Metaname Test API Key" if use_test_api else "Metaname Prod API Key"
+domain = "testjjobs.nz" if use_test_api else "getjjobs.nz"
+subdomain = "dev"
+cname_value = "cname.vercel-dns.com."
+
+# --- Fetch credentials from 1Password ---
+def fetch_op_field(item, field, vault):
+    return subprocess.check_output([
+        "op", "item", "get", item,
+        "--vault", vault,
+        "--field", field,
+        "--reveal"
+    ]).decode().strip()
+
+account_reference = fetch_op_field(item_name, "account_reference", vault_name)
+api_key = fetch_op_field(item_name, "credential", vault_name)
+
+# --- Compose the DNS record ---
+record = {
+    "name": subdomain,
+    "type": "CNAME",
+    "ttl": 3600,
+    "aux": None,
+    "data": cname_value
+}
+
+# --- Make the request ---
+print(f"Creating CNAME {subdomain}.{domain} → {cname_value}")
+response = requests.post(API_ENDPOINT, json={
+    "jsonrpc": "2.0",
+    "method": "create_dns_record",
+    "params": [account_reference, api_key, domain, record],
+    "id": 1
+})
+
+# --- Handle response ---
+print("Status:", response.status_code)
+try:
+    result = response.json()
+    print("Response:", json.dumps(result, indent=2))
+except Exception as e:
+    print("Failed to decode JSON response:", e)
+    print("Raw Response:", response.text)


### PR DESCRIPTION
I've created a script which will create the dev cname, the script can be used to test the change/record setup in the test Metaname system.   Once that was working, I flipped the flag to production: 

```
# --- Toggle for test or production ---
use_test_api = False  # Set to False to use the production API
```

And ran the script: 

```
INFRA/DNS on  task/register-the-domain-name [?] via 🐍 v3.12.3 
❯ python add-dev-cname.py 
Creating CNAME dev.getjjobs.nz → cname.vercel-dns.com.
Status: 200
Response: {
  "id": 1,
  "result": "144259",
  "jsonrpc": "2.0"
}
```

This is pointing at Vercel now: 

```
INFRA/DNS on  task/add-dev-cname via 🐍 v3.12.3 
❯ ping dev.getjjobs.nz
PING cname.vercel-dns.com (76.76.21.142) 56(84) bytes of data.
64 bytes from 76.76.21.142: icmp_seq=1 ttl=250 time=16.2 ms
64 bytes from 76.76.21.142: icmp_seq=2 ttl=250 time=16.4 ms
64 bytes from 76.76.21.142: icmp_seq=3 ttl=250 time=17.0 ms
^C
--- cname.vercel-dns.com ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 2004ms
rtt min/avg/max/mdev = 16.158/16.515/16.985/0.346 ms

```

Over to @b0nsun9  to test if it works. 