### PR TITLE
Add Netlify CNAME and A records

### DIFF
--- a/DNS/add-apex-a-records.py
+++ b/DNS/add-apex-a-records.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""
+Create A records for the apex domain using Metaname's create_dns_record method.
+Supports both test and production environments.
+"""
+
+import requests
+import subprocess
+import json
+
+# --- Toggle for test or production ---
+use_test_api = False  # Set to False to use the production API
+
+API_ENDPOINT = (
+    "https://test.metaname.net/api/1.1"
+    if use_test_api else
+    "https://metaname.net/api/1.1"
+)
+vault_name = "JJobs"
+item_name = "Metaname Test API Key" if use_test_api else "Metaname Prod API Key"
+domain = "testjjobs.nz" if use_test_api else "getjjobs.nz"
+
+# --- A records required for Netlify apex domain support ---
+apex_ips = ["75.2.60.5", "99.83.190.102"]
+
+# --- Fetch credentials from 1Password ---
+def fetch_op_field(item, field, vault):
+    return subprocess.check_output([
+        "op", "item", "get", item,
+        "--vault", vault,
+        "--field", field,
+        "--reveal"
+    ]).decode().strip()
+
+account_reference = fetch_op_field(item_name, "account_reference", vault_name)
+api_key = fetch_op_field(item_name, "credential", vault_name)
+
+# --- Loop over IPs and create A records ---
+for ip in apex_ips:
+    record = {
+        "name": "@",
+        "type": "A",
+        "ttl": 3600,
+        "aux": None,
+        "data": ip
+    }
+
+    print(f"Creating A record {domain} → {ip}")
+    response = requests.post(API_ENDPOINT, json={
+        "jsonrpc": "2.0",
+        "method": "create_dns_record",
+        "params": [account_reference, api_key, domain, record],
+        "id": 1
+    })
+
+    print("Status:", response.status_code)
+    try:
+        result = response.json()
+        print("Response:", json.dumps(result, indent=2))
+    except Exception as e:
+        print("Failed to decode JSON response:", e)
+        print("Raw Response:", response.text)

--- a/DNS/add-www-netlify-cname.py
+++ b/DNS/add-www-netlify-cname.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""
+Create a CNAME record for dev subdomain using Metaname's create_dns_record method.
+Supports both test and production environments.
+"""
+
+import requests
+import subprocess
+import json
+
+# --- Toggle for test or production ---
+use_test_api = False  # Set to False to use the production API
+
+API_ENDPOINT = (
+    "https://test.metaname.net/api/1.1"
+    if use_test_api else
+    "https://metaname.net/api/1.1"
+)
+vault_name = "JJobs"
+item_name = "Metaname Test API Key" if use_test_api else "Metaname Prod API Key"
+domain = "testjjobs.nz" if use_test_api else "getjjobs.nz"
+subdomain = "www"
+cname_value = "getjjobs.netlify.app."
+
+# --- Fetch credentials from 1Password ---
+def fetch_op_field(item, field, vault):
+    return subprocess.check_output([
+        "op", "item", "get", item,
+        "--vault", vault,
+        "--field", field,
+        "--reveal"
+    ]).decode().strip()
+
+account_reference = fetch_op_field(item_name, "account_reference", vault_name)
+api_key = fetch_op_field(item_name, "credential", vault_name)
+
+# --- Compose the DNS record ---
+record = {
+    "name": subdomain,
+    "type": "CNAME",
+    "ttl": 3600,
+    "aux": None,
+    "data": cname_value
+}
+
+# --- Make the request ---
+print(f"Creating CNAME {subdomain}.{domain} → {cname_value}")
+response = requests.post(API_ENDPOINT, json={
+    "jsonrpc": "2.0",
+    "method": "create_dns_record",
+    "params": [account_reference, api_key, domain, record],
+    "id": 1
+})
+
+# --- Handle response ---
+print("Status:", response.status_code)
+try:
+    result = response.json()
+    print("Response:", json.dumps(result, indent=2))
+except Exception as e:
+    print("Failed to decode JSON response:", e)
+    print("Raw Response:", response.text)


### PR DESCRIPTION
Run this script to set the CNAME

```
INFRA/DNS on  bau/add-www-netlify-cname [?] via 🐍 v3.12.3 took 4s 
❯ python add-www-netlify-cname.py 
Creating CNAME www.getjjobs.nz → getjjobs.netlify.app.
Status: 200
Response: {
  "result": "146391",
  "jsonrpc": "2.0",
  "id": 1
}
```

And this to set the A records for the Apex domain: 

```
INFRA/DNS on  bau/add-www-netlify-cname [?] via 🐍 v3.12.3 took 9s 
❯ python add-apex-a-records.py 
Creating A record getjjobs.nz → 75.2.60.5
Status: 200
Response: {
  "result": "146394",
  "jsonrpc": "2.0",
  "id": 1
}
Creating A record getjjobs.nz → 99.83.190.102
Status: 200
Response: {
  "result": "146395",
  "jsonrpc": "2.0",
  "id": 1
}
```

Just quick and dirty scripts, I'll come back around later and create a nicer module and GHA pipeline for managing DNS. 